### PR TITLE
dictionary db name may include a HYPHEN MINUS

### DIFF
--- a/lib/Net/Dict.pm
+++ b/lib/Net/Dict.pm
@@ -220,7 +220,7 @@ sub define
         my ($defNum) = ($self->message =~ /^\d{3} (\d+) /);
         foreach (0..$defNum-1)
         {
-            my ($d) = ($self->getline =~ /^\d{3} ".*" (\w+) /);
+            my ($d) = ($self->getline =~ /^\d{3} ".*" ([-\w]+) /);
             my ($def) = join '', @{$self->read_until_dot};
             push @defs, [$d, $def];
         }


### PR DESCRIPTION
without this, we think the name is (undef) and get an uninitialized
warning
