### PR TITLE
Fix unicode to latin-1 translation.

### DIFF
--- a/examples/portuguese.pl
+++ b/examples/portuguese.pl
@@ -34,8 +34,9 @@ $| = 1;
 #-----------------------------------------------------------------------
 # Create instance of Net::Dict, connecting to the server
 #-----------------------------------------------------------------------
-print "Connecting to $host ...";
-$dict = Net::Dict->new($host);   
+print "Connecting to $host ...\n";
+$dict = Net::Dict->new($host);
+die "Could not connect: $!" if !defined $dict;
 $dict->setDicts($database);
 
 #-----------------------------------------------------------------------
@@ -58,8 +59,6 @@ while(<>)
 	foreach $entry (@$eref)
 	{
 	    ($db, $translation) = @$entry;
-	    $translation =~ y/[\200-\377]/[\200-\377]/UC;
-
 	    print "$db--------\n",$translation;
 	}
     }


### PR DESCRIPTION
The `UC` (unicode to Latin-1) option for the `tr//` operator (see [perldoc for perl 5.6](https://perldoc.perl.org/5.6.0/perlop.html#Regexp-Quote-Like-Operators) was removed in perl 5.7.0 (see [perl570delta](https://perldoc.perl.org/5.8.0/perl570delta.html). It is not possible to include the statement conditional based on `$]` either,  e.g. if `$]` is less than 5.008, since the code will anyway not compile on newer versions of perl (giving a syntax error). 

I suggest to drop support for perl version 5.7 and below by removing the transliteration (I think it is no longer correct to translate to unicode to latin-1 like that). 

Note: I was not able to test if this fix works since I could not connect to the server. I get:
```
$ perl portuguese.pl
Connecting to natura.di.uminho.pt ...
Could not connect: Connection refused at portuguese.pl line 39.
```

Note: This PR is part of assignment from [pullrequest.club](https://pullrequest.club/). See also [this](https://stackoverflow.com/a/63150295/2173773) answer on stackoverflow.